### PR TITLE
generate bindings for Xen only

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,9 @@
-extern crate bindgen;
+use std::{env, path::PathBuf};
 
-use std::env;
-use std::path::PathBuf;
+static XEN_HEADERS_WRAPPER: &str = "src/wrapper.h";
 
 fn main() {
-
-    // what library to link with
-    println!("cargo:rustc-link-lib=xenctrl");
+    println!("cargo:rerun-if-changed={}", XEN_HEADERS_WRAPPER);
 
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
@@ -14,15 +11,27 @@ fn main() {
     let bindings = bindgen::Builder::default()
         // The input header we would like to generate
         // bindings for.
-        .header("src/wrapper.h")
+        .header(XEN_HEADERS_WRAPPER)
+        // Generate bindings for Xen specific types
+        // and functions only.
+        .whitelist_function("xc_.*")
+        // Keep C's enums as Rust's enums.
+        .default_enum_style(bindgen::EnumVariation::Rust)
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.
         .expect("Unable to generate bindings");
 
     // Write the bindings to the $OUT_DIR/bindings.rs file.
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let out_path = {
+        let out_path =
+            env::var("OUT_DIR").expect("Unable to get OUT_DIR environment variable");
+        PathBuf::from(out_path)
+    };
     bindings
         .write_to_file(out_path.join("bindings.rs"))
-        .expect("Couldn't write bindings!");
+        .expect("Unable to write bindings!");
+
+    // what library to link with
+    println!("cargo:rustc-link-lib={}={}", "dylib", "xenctrl");
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+edition = "2018"
+indent_style = "block"
+format_string = "true"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,9 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+mod gen {
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}
+
+// Re-exports
+pub use gen::*;


### PR DESCRIPTION
Hello all,

The PR does
 - Restrain the binding generation on Xen specific types and functions
 - Keep C's enums/unions as Rust's enums/unions
 - Add _rerun_ notification to invoke the bindings whenever the header wrapper is modified
- Add a rustfmt configuration.

Many thanks for comments.