### PR TITLE
Disable non_exhaustive for Rust enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ licence-file = "LICENSE"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.49.2"
+bindgen = "0.49.3"

--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,7 @@ fn main() {
         // and functions only.
         .whitelist_function("xc_.*")
         // Keep C's enums as Rust's enums.
-        .default_enum_style(bindgen::EnumVariation::Rust)
+        .default_enum_style(bindgen::EnumVariation::Rust { non_exhaustive: false })
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.


### PR DESCRIPTION
Because of [this PR](https://github.com/rust-lang/rust-bindgen/pull/1575) on bindgen, now we need explicitly set value for `non_exhaustive` for `EnumVariation::Rust`