### PR TITLE
export Xen constants/functions/types only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,11 @@ links = "xenctrl"
 repository = "https://github.com/Wenzel/xen-sys"
 readme = "README.md"
 keywords = ["xen", "introspection"]
+categories = ["external-ffi-bindings"]
 description = "Rust bindings for Xen's xenctrl library"
 license = "GPL-3.0-only"
 
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.49.3"
+bindgen = "0.49.2"

--- a/build.rs
+++ b/build.rs
@@ -14,9 +14,15 @@ fn main() {
         .header(XEN_HEADERS_WRAPPER)
         // Generate bindings for Xen specific types
         // and functions only.
-        // .whitelist_function("xc_.*")
+        .whitelist_function("xc_.*")
+        // Generate bindings for Xen specific constants.
+        .whitelist_var("XC_.*")
         // Keep C's enums as Rust's enums.
-        // .default_enum_style(bindgen::EnumVariation::Rust { non_exhaustive: false })
+        .default_enum_style(bindgen::EnumVariation::Rust)
+        // Disable data layout tests.
+        .layout_tests(false)
+        // Don't run rustfmt on the bindings
+        .rustfmt_bindings(false)
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.
@@ -24,8 +30,7 @@ fn main() {
 
     // Write the bindings to the $OUT_DIR/bindings.rs file.
     let out_path = {
-        let out_path =
-            env::var("OUT_DIR").expect("Unable to get OUT_DIR environment variable");
+        let out_path = env::var("OUT_DIR").expect("Unable to get OUT_DIR environment variable");
         PathBuf::from(out_path)
     };
     bindings

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,6 @@
 edition = "2018"
 indent_style = "block"
-format_string = "true"
+format_strings = true
+merge_imports = true
+reorder_imports = true
+wrap_comments = true


### PR DESCRIPTION
- whitelist Xen constants (e.g. `XC_PAGE_SHIFT`, `XC_PAGE_SIZE`, `XC_PAGE_MASK`, etc.)
- add categories for crate