### PR TITLE
Increase version of bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xenctrl-sys"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Mathieu Tarral <mathieu.tarral@protonmail.com>"]
 edition = "2018"
 description = "Rust FFI bindings for libxenctrl"
@@ -16,4 +16,4 @@ build = "build.rs"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.51.1"
+bindgen = "0.69.4"

--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,7 @@ fn main() {
         // Disable data layout tests.
         .layout_tests(false)
         // Run rustfmt on the bindings
-        .rustfmt_bindings(true)
+        .formatter(bindgen::Formatter::Rustfmt)
         //initialize structs with default values
         .derive_default(true)
         // Finish the builder and generate the bindings.


### PR DESCRIPTION
When trying to generate bindings, I realized that bindgen.rs was struggling with the version of xen I am using (`xen 4.18.1pre-1`).

Updating bindgen to "0.69.4" fixes the issue.
In addition, `rustfmt_bindings` is now deprecated, replaced it with `.formatter(bindgen::Formatter::Rustfmt)` although the whole thing is not really needed since the the formatting is enabled by default.

Bumped the crate version to reflect the changes.